### PR TITLE
feat: support Github Enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ jobs:
 | - | - | - | - |
 | token | Github token | `true` |  |
 | src_repo | Source repo to clone from | `true` |  |
+| src_repo_github_api_url | API repo for the src_repo. Defaults to Github. Set this if using GHE | `false` | https://api.github.com |
 | dest_repo | Destination repo to clone to, default is this repo | `false` |  |
+| dest_repo_github_api_url | API repo for the dest_repo. Defaults to Github. Set this if using GHE | `false` | https://api.github.com |
 | target | Target for new tags/releases in this repo. If not set, will use the default branch | `false` |  |
 | skip_draft | Skip draft releases | `false` | false |
 | skip_prerelease | Skip Prereleases | `false` | false |

--- a/action.yml
+++ b/action.yml
@@ -8,9 +8,17 @@ inputs:
   src_repo:
     description: "Source repo to clone from"
     required: true
+  src_repo_github_api_url:
+    description: "API repo for the src_repo. Defaults to Github. Set this if using GHE"
+    required: false
+    default: "https://api.github.com"
   dest_repo:
     description: "Destination repo to clone to, default is this repo"
     required: false
+  dest_repo_github_api_url:
+    description: "API repo for the dest_repo. Defaults to Github. Set this if using GHE"
+    required: false
+    default: "https://api.github.com"
   target:
     description: "Target for new tags/releases in this repo. If not set, will use the default branch"
     default: ""


### PR DESCRIPTION
Adds new inputs that allow configuring the API url for the source and
destination repos, allowing use of this action with Github Enterprise