### PR TITLE
feat: Add possibility to dissociate token for source and destination repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ jobs:
 | parameter | description | required | default |
 | - | - | - | - |
 | token | Github token | `true` |  |
+| dest_token | Github token used for destination repo. If not set, `token` parameter is used. | `false` |  |
 | src_repo | Source repo to clone from | `true` |  |
 | src_repo_github_api_url | API repo for the src_repo. Defaults to Github. Set this if using GHE | `false` | https://api.github.com |
 | dest_repo | Destination repo to clone to, default is this repo | `false` |  |

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ inputs:
   token:
     description: "Github token"
     required: true
+  dest_token:
+    description: "Github token used for destination repo. If not set, token parameter is used"
+    required: false
   src_repo:
     description: "Source repo to clone from"
     required: true

--- a/gha_clone_releases/main.py
+++ b/gha_clone_releases/main.py
@@ -12,6 +12,10 @@ from gha_clone_releases.utils.releases import get_missing_releases
 ###START_INPUT_AUTOMATION###
 INPUTS = {
     "token": {"description": "Github token", "required": True},
+    "dest_token": {
+        "description": "Github token used for destination repo. If not set, token parameter is used",
+        "required": False
+      },
     "src_repo": {"description": "Source repo to clone from", "required": True},
     "src_repo_github_api_url": {
         "description": "API repo for the src_repo. Defaults to Github. Set this if using GHE",
@@ -116,7 +120,10 @@ def main():
     dest_github = (
         src_github
         if inputs["dest_repo_github_api_url"] == inputs["src_repo_github_api_url"]
-        else Github(inputs["token"], base_url=inputs["dest_repo_github_api_url"])
+        else Github(
+            inputs["dest_token"] if "dest_token" in inputs else inputs["token"],
+            base_url=inputs["dest_repo_github_api_url"]
+        )
     )
     src_releases = src_github.get_repo(inputs["src_repo"]).get_releases()
 


### PR DESCRIPTION
Hi,

Thank you for developing this valuable action! It's been very helpful. However, for our specific business needs, we require the ability to specify two separate tokens.

In our scenario, we use a PAT from another organization to read content from a source repository. Unfortunately, this PAT does not grant access to our repository within our organization.

The purpose of this PR is to introduce the option to specify a dedicated token for the destination repository. This new parameter is optional; in its absence, the system will default to using the existing token. I've retained the original token parameter name to maintain backward compatibility.

I appreciate your time in reviewing this PR and look forward to your feedback.

Thank you.


