### PR TITLE
feat: support a separate token for destination 

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ jobs:
 | parameter | description | required | default |
 | - | - | - | - |
 | token | Github token | `true` |  |
+| dest_token | Github token used for destination repo. If not set, token parameter is used | `false` |  |
 | src_repo | Source repo to clone from | `true` |  |
 | src_repo_github_api_url | API repo for the src_repo. Defaults to Github. Set this if using GHE | `false` | https://api.github.com |
 | dest_repo | Destination repo to clone to, default is this repo | `false` |  |

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ inputs:
   token:
     description: "Github token"
     required: true
+  dest_token:
+    description: "Github token used for destination repo. If not set, token parameter is used"
+    required: false
   src_repo:
     description: "Source repo to clone from"
     required: true

--- a/gha_clone_releases/main.py
+++ b/gha_clone_releases/main.py
@@ -123,7 +123,7 @@ def main():
     dest_github = (
         src_github
         if inputs["dest_repo_github_api_url"] == inputs["src_repo_github_api_url"]
-        else Github(inputs["token"], base_url=inputs["dest_repo_github_api_url"])
+        else Github(inputs["dest_token"], base_url=inputs["dest_repo_github_api_url"])
     )
     src_releases = src_github.get_repo(inputs["src_repo"]).get_releases()
 

--- a/gha_clone_releases/main.py
+++ b/gha_clone_releases/main.py
@@ -12,6 +12,10 @@ from gha_clone_releases.utils.releases import get_missing_releases
 ###START_INPUT_AUTOMATION###
 INPUTS = {
     "token": {"description": "Github token", "required": True},
+    "dest_token": {
+        "description": "Github token used for destination repo. If not set, token parameter is used",
+        "required": False,
+    },
     "src_repo": {"description": "Source repo to clone from", "required": True},
     "src_repo_github_api_url": {
         "description": "API repo for the src_repo. Defaults to Github. Set this if using GHE",
@@ -100,6 +104,9 @@ def get_inputs() -> dict[str, Any]:
     )
     parsed_inputs["dest_repo"] = (
         os.environ.get("GITHUB_REPOSITORY") if parsed_inputs["dest_repo"] is None else parsed_inputs["dest_repo"]
+    )
+    parsed_inputs["dest_token"] = (
+        parsed_inputs["token"] if parsed_inputs["dest_token"] is None else parsed_inputs["dest_token"]
     )
     if parsed_inputs["dest_repo"] is None:
         actions_toolkit.set_failed("Dest repo is none, set either INPUT_DEST_REPO or GITHUB_REPOSITORY")


### PR DESCRIPTION
This implements the feature @sebastienrospars suggested in
https://github.com/andrewthetechie/gha-clone-releases/pull/174

It adds a new optional input, dest_token. When dest_token is supplied, it is used with the 
Github connection to the destination repo. 